### PR TITLE
Delete instead of upload in delete response

### DIFF
--- a/products/image-resizing/src/content/cloudflare-images-beta.md
+++ b/products/image-resizing/src/content/cloudflare-images-beta.md
@@ -77,7 +77,7 @@ curl -X DELETE https://api.cloudflare.com/client/v4/accounts/$account_tag/images
 
 ```
 
-If the upload is successful, you can expect a JSON response body similar to this:
+If the delete is successful, you can expect a JSON response body similar to this:
 
 ```json
 {


### PR DESCRIPTION
The delete response text is the same for the upload. Maybe it should say "delete" rather than "upload"?